### PR TITLE
Small improvements from cr

### DIFF
--- a/calendar_data/data.py
+++ b/calendar_data/data.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date
 
 import requests
 from icalendar import Calendar
@@ -13,11 +13,8 @@ def get_future_events(pyvo_events_url):
     data = get_calendar_data(pyvo_events_url)
     gcal = Calendar.from_ical(data)
     for event in gcal.walk():
-        # tzinfo=None removes timezone information from events,
-        # as both datetimes need to be either in the same timezone
-        # or not to have any timezone information for the comparison to work
         if (
             event.name == "VEVENT"
-            and event["dtstart"].dt.replace(tzinfo=None) > datetime.today()
+            and event["dtstart"].dt.date() > date.today()
         ):
             yield event

--- a/calendar_data/data.py
+++ b/calendar_data/data.py
@@ -1,15 +1,17 @@
 from datetime import date
-
+from typing import Generator, Dict, Any
 import requests
 from icalendar import Calendar
 
 
-def get_calendar_data(pyvo_events_url):
+def get_calendar_data(pyvo_events_url: str) -> bytes:
     calendar_raw_data = requests.get(pyvo_events_url)
     return calendar_raw_data.content
 
 
-def get_future_events(pyvo_events_url):
+def get_future_events(
+    pyvo_events_url: str,
+) -> Generator[Dict[str, Any], None, None]:
     data = get_calendar_data(pyvo_events_url)
     gcal = Calendar.from_ical(data)
     for event in gcal.walk():

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -22,7 +22,9 @@ def send_message(chat_id, text):
 def send_message_to_prague_channel():
     events = get_future_events("https://pyvo.cz/api/series/praha-pyvo.ics")
     for event in events:
-        summary = event["summary"].replace("(", "").replace(")", "")
+        summary = event["summary"]
+        # fix for https://github.com/pyvec/pyvo.cz/issues/161
+        output_summary = summary[1:-1]
         event_date = event["dtstart"].dt.date()
         output_event_date = event["dtstart"].dt.date().strftime("%d.%m.%Y")
         date_difference = (event_date - date.today()).days
@@ -30,15 +32,15 @@ def send_message_to_prague_channel():
             case 7:
                 send_message(
                     PRAGUE_CHAT_ID,
-                    f"Next week! {output_event_date}, {summary}",
+                    f"Next week! {output_event_date}, {output_summary}",
                 )
             case 3:
                 send_message(
                     PRAGUE_CHAT_ID,
-                    f"In three days! {output_event_date}, {summary}",
+                    f"In three days! {output_event_date}, {output_summary}",
                 )
             case 0:
                 send_message(
                     PRAGUE_CHAT_ID,
-                    f"Tonight! {output_event_date}, {summary}",
+                    f"Tonight! {output_event_date}, {output_summary}",
                 )

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -4,12 +4,13 @@ from datetime import date
 import requests
 
 from calendar_data.data import get_future_events
+from typing import Dict
 
 TELEGRAM_TOKEN = os.environ["TELEGRAM_TOKEN"]
 PRAGUE_CHAT_ID = "-1001837942773"  # test chat
 
 
-def send_message(chat_id, text):
+def send_message(chat_id: str, text: str) -> Dict[str, str]:
     token = TELEGRAM_TOKEN
     response = requests.post(
         url=f"https://api.telegram.org/bot{token}/sendMessage",
@@ -19,7 +20,7 @@ def send_message(chat_id, text):
     return response.json()
 
 
-def send_message_to_prague_channel():
+def send_message_to_prague_channel() -> None:
     events = get_future_events("https://pyvo.cz/api/series/praha-pyvo.ics")
     for event in events:
         summary = event["summary"]

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import date
 
 import requests
 
@@ -23,9 +23,9 @@ def send_message_to_prague_channel():
     events = get_future_events("https://pyvo.cz/api/series/praha-pyvo.ics")
     for event in events:
         summary = event["summary"].replace("(", "").replace(")", "")
-        event_date = event["dtstart"].dt.replace(tzinfo=None).date()
+        event_date = event["dtstart"].dt.date()
         output_event_date = event["dtstart"].dt.date().strftime("%d.%m.%Y")
-        date_difference = (event_date - datetime.today().date()).days
+        date_difference = (event_date - date.today()).days
         match date_difference:
             case 7:
                 send_message(

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -23,8 +23,6 @@ def send_message_to_prague_channel():
     events = get_future_events("https://pyvo.cz/api/series/praha-pyvo.ics")
     for event in events:
         summary = event["summary"]
-        # fix for https://github.com/pyvec/pyvo.cz/issues/161
-        output_summary = summary[1:-1]
         event_date = event["dtstart"].dt.date()
         output_event_date = event["dtstart"].dt.date().strftime("%d.%m.%Y")
         date_difference = (event_date - date.today()).days
@@ -32,15 +30,15 @@ def send_message_to_prague_channel():
             case 7:
                 send_message(
                     PRAGUE_CHAT_ID,
-                    f"Next week! {output_event_date}, {output_summary}",
+                    f"Next week! {output_event_date}, {summary}",
                 )
             case 3:
                 send_message(
                     PRAGUE_CHAT_ID,
-                    f"In three days! {output_event_date}, {output_summary}",
+                    f"In three days! {output_event_date}, {summary}",
                 )
             case 0:
                 send_message(
                     PRAGUE_CHAT_ID,
-                    f"Tonight! {output_event_date}, {output_summary}",
+                    f"Tonight! {output_event_date}, {summary}",
                 )

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -7,7 +7,7 @@ from calendar_data.data import get_future_events
 from typing import Dict
 
 TELEGRAM_TOKEN = os.environ["TELEGRAM_TOKEN"]
-PRAGUE_CHAT_ID = "-1001837942773"  # test chat
+PRAGUE_CHAT_ID = "-1001168385726"
 
 
 def send_message(chat_id: str, text: str) -> Dict[str, str]:
@@ -28,7 +28,7 @@ def send_message_to_prague_channel() -> None:
         output_event_date = event["dtstart"].dt.date().strftime("%d.%m.%Y")
         date_difference = (event_date - date.today()).days
         match date_difference:
-            case 7:
+            case 6:
                 send_message(
                     PRAGUE_CHAT_ID,
                     f"Next week! {output_event_date}, {summary}",


### PR DESCRIPTION
Addressing issues from [PR](https://github.com/pyvec/pyvo-bot/pull/1).

> That definitely looks like a bug in https://github.com/pyvec/pyvo.cz/ as it seems the summary contains an accidentally "stringified" Python tuple.
_Originally posted by @honzajavorek in https://github.com/pyvec/pyvo-bot/pull/1#discussion_r986676585_

 <del>I've created a [bug](https://github.com/pyvec/pyvo.cz/issues/161) and tried to fix my code by removing the first and last character of the string. It works, as long as the bug is present (I should think about how to make sure that I update it immediately after the bug is fixed). </del> It's not a bug - it's only for unconfirmed events. If an event is confirmed, then the `(` `)` disappear. Now the question is, if it's necessary to include some check, if an event is confirmed or not in the code. AFAIK Pyvo was never skipped, except of COVID online ones together with Brno. It could be added to the _ToDo_ section of the documentation for further possible improvements.

Regarding the two other comments (https://github.com/pyvec/pyvo-bot/pull/1#discussion_r986103838, https://github.com/pyvec/pyvo-bot/pull/1#discussion_r986103224) about datetime - it does indeed make more sense to work with dates only, as we don't need time, thus I updated the code accordingly.  
      
I've also added the type hints. 

I changed days till Pyvo to 6, as I realized that sometimes we update the web 7 days in advance, so the script would send the message on the following day, i.e. on Thursday morning.